### PR TITLE
Bugfix: 실물 노트의 stroke가 뷰어와 싱크가 맞지 않는 부분 수정

### DIFF
--- a/src/renderer/PenBasedRenderer.tsx
+++ b/src/renderer/PenBasedRenderer.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 import PenHelper from '../utils/PenHelper';
 import { fabric } from 'fabric';
 import api from '../server/NoteServer';
-import { PageInfo } from '../utils/type';
+import { PageInfo, PaperBase } from '../utils/type';
 
 const useStyle = makeStyles(() => ({
   mainBackground: {
@@ -28,6 +28,8 @@ const PenBasedRenderer = () => {
   const [ncodeWidth, setNcodeWidth] = useState(0);
   const [ncodeHeight, setNcodeHeight] = useState(0); 
 
+  const [paperBase, setPaperBase] = useState<PaperBase>({Xmin: 0, Ymin: 0});
+
   // canvas size
   useEffect(() => {
     setCanvasFb(initCanvas());
@@ -37,6 +39,10 @@ const PenBasedRenderer = () => {
     if (pageInfo) {
       // Ncode Info
       const ncodeSize = api.extractMarginInfo(pageInfo);
+      if (ncodeSize !== undefined) {
+        setPaperBase({Xmin: ncodeSize.Xmin, Ymin: ncodeSize.Ymin})
+      }
+
       let ncodeWidth, ncodeHeight;
       if (ncodeSize) {
         ncodeWidth = ncodeSize.Xmax - ncodeSize.Xmin;
@@ -104,8 +110,8 @@ const PenBasedRenderer = () => {
      * 
      */
     // Calculate dot ratio
-    const dx = (dot.x * canvasFb.width) / ncodeWidth;
-    const dy = (dot.y * canvasFb.height) / ncodeHeight;
+    const dx = ((dot.x - paperBase.Xmin) * canvasFb.width) / ncodeWidth;
+    const dy = ((dot.y - paperBase.Ymin) * canvasFb.height) / ncodeHeight;
 
     // Pen Down
     if (dot.dotType === 0) {

--- a/src/utils/type.ts
+++ b/src/utils/type.ts
@@ -5,6 +5,12 @@ type PageInfo = {
   page: number;
 };
 
+type PaperBase = {
+  Xmin: number;
+  Ymin: number;
+}
+
 export type { 
   PageInfo,
+  PaperBase,
 };


### PR DESCRIPTION
- 실물 노트의 stroke가 뷰어와 싱크가 맞지 않는 부분 수정
- Xmin, Ymin을 설정해줌으로써 해결